### PR TITLE
Enable logs retrieval after course deletion by storing metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,10 @@
+# .github/workflows/ci.yml
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main
+    with:
+       extra_plugin_runners: 'moodle-plugin-ci add-plugin catalyst/moodle-tool_lifecycle'

--- a/classes/lifecycle/log_table.php
+++ b/classes/lifecycle/log_table.php
@@ -14,14 +14,28 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Course backup logs table.
+ *
+ * @package     tool_lcbackupcourselogstep
+ * @copyright   2024 Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 namespace tool_lcbackupcourselogstep\lifecycle;
 
 defined('MOODLE_INTERNAL') || die;
 
 require_once($CFG->libdir . '/tablelib.php');
 
-class log_table extends \table_sql
-{
+/**
+ * Backup log table.
+ *
+ * @package     tool_lcbackupcourselogstep
+ * @copyright   2024 Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class log_table extends \table_sql {
 
     /**
      * @var array "cached" lang strings
@@ -32,16 +46,16 @@ class log_table extends \table_sql
      * Constructor for delayed_courses_table.
      *
      * @throws \coding_exception
+     * @param array $filterdata Filter data.
      */
-    public function __construct($filterdata = [])
-    {
+    public function __construct($filterdata = []) {
         global $DB;
 
         parent::__construct('tool_lcbackupcourselogstep-log');
 
-        // Action buttons string
+        // Action buttons string.
         $this->strings = [
-            'download' => get_string('download')
+            'download' => get_string('download'),
         ];
 
         // Build the SQL.
@@ -50,7 +64,7 @@ class log_table extends \table_sql
                    f.filename as filename, f.filesize as filesize, f.timecreated as createdat';
         $from = '{files} f
                  JOIN {context} c ON c.id = f.contextid
-                 LEFT JOIN {tool_lcbackupcourselogstep_metadata} md ON f.id = md.fileid';         
+                 LEFT JOIN {tool_lcbackupcourselogstep_metadata} md ON f.id = md.fileid';
 
         $where = ["f.component = :component AND filename <> '.'"];
         $params = ['component' => 'tool_lcbackupcourselogstep'];
@@ -76,7 +90,6 @@ class log_table extends \table_sql
         $where = join(" AND ", $where);
 
         $this->set_sql($fields, $from, $where, $params);
-
 
         // Columns.
         $this->define_columns([
@@ -108,15 +121,12 @@ class log_table extends \table_sql
     }
 
     /**
-     * Define download action.
+     * Download action column.
      *
-     * @param $row
-     * @return bool|string
-     * @throws \coding_exception
-     * @throws \moodle_exception
+     * @param object $row
+     * @return string
      */
-    public function col_actions($row)
-    {
+    public function col_actions($row) {
         global $OUTPUT;
 
         $actionmenu = new \action_menu();
@@ -132,21 +142,19 @@ class log_table extends \table_sql
     }
 
     /**
-     * Time when the file is created, displayed in user-friendly format.
+     * Display time when the file was created.
      *
-     * @param $row
+     * @param object $row
      * @return string
-     * @throws \coding_exception
      */
-    public function col_createdat($row)
-    {
+    public function col_createdat($row) {
         return userdate($row->createdat);
     }
 
     /**
-     * Display size in a user-friendly format.
+     * Display size in user friendly format.
      *
-     * @param $row
+     * @param object $row
      * @return string
      */
     public function col_filesize($row) {

--- a/classes/lifecycle/step.php
+++ b/classes/lifecycle/step.php
@@ -14,7 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Step for backing up a course logs in the lifecycle process.
+ *
+ * @package    tool_lcbackupcourselogstep
+ * @copyright  2024 Catalyst
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 namespace tool_lcbackupcourselogstep\lifecycle;
+
+defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/admin/tool/lifecycle/step/lib.php');
@@ -28,32 +38,52 @@ use tool_lifecycle\settings_type;
 use tool_lifecycle\step\instance_setting;
 use tool_lifecycle\step\libbase;
 
-defined('MOODLE_INTERNAL') || die();
-
+/**
+ * Step class for the Backup Course Log Step plugin.
+ *
+ * @package    tool_lcbackupcourselogstep
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 class step extends libbase {
-    public function get_subpluginname()
-    {
+    /**
+     * Returns the subplugin name.
+     *
+     * @return string
+     */
+    public function get_subpluginname() {
         return 'tool_lcbackupcourselogstep';
     }
 
+    /**
+     * Get the plugin description.
+     *
+     * @return string
+     */
     public function get_plugin_description() {
         return "Backup course log step plugin";
     }
 
-    public function process_course($processid, $instanceid, $course)
-    {
+    /**
+     * Processes the course.
+     *
+     * @param int $processid the process id.
+     * @param int $instanceid step instance id.
+     * @param object $course the course object.
+     * @return step_response
+     */
+    public function process_course($processid, $instanceid, $course) {
         global $DB;
 
         // Get all logs for the course with related courses and user details.
         $sql = "SELECT log.*, c.shortname as courseshortname, c.fullname as coursefullname,
-                    u1.firstname as userfirstname, u1.lastname as userlastname, 
+                    u1.firstname as userfirstname, u1.lastname as userlastname,
                     u2.firstname as realuserfirstname, u2.lastname as realuserlastname,
-                    u3.firstname as relateduserfirstname, u3.lastname as relateduserlastname 
-                  FROM {logstore_standard_log} as log
-                  LEFT JOIN {course} as c ON log.courseid = c.id
-                  LEFT JOIN {user} as u1 ON log.userid = u1.id
-                  LEFT JOIN {user} as u2 ON log.realuserid = u2.id
-                  LEFT JOIN {user} as u3 ON log.relateduserid = u3.id
+                    u3.firstname as relateduserfirstname, u3.lastname as relateduserlastname
+                  FROM {logstore_standard_log} log
+                  LEFT JOIN {course} c ON log.courseid = c.id
+                  LEFT JOIN {user} u1 ON log.userid = u1.id
+                  LEFT JOIN {user} u2 ON log.realuserid = u2.id
+                  LEFT JOIN {user} u3 ON log.relateduserid = u3.id
                  WHERE courseid = :courseid";
 
         // Get all logs for the course.
@@ -106,19 +136,30 @@ class step extends libbase {
             'fullname' => $course->fullname,
             'oldcourseid' => $course->id,
             'fileid' => $newfile->get_id(),
-            'timecreated' => time()
+            'timecreated' => time(),
         ]);
 
         // Proceed.
         return step_response::proceed();
     }
 
+    /**
+     * Returns instance settings for the plugin.
+     *
+     * @return array The instance settings for this step.
+     */
     public function instance_settings() {
         return [
             new instance_setting('fileformat', PARAM_TEXT, true),
         ];
     }
 
+    /**
+     * Extend the instance form to add file format options.
+     *
+     * @param \MoodleQuickForm $mform The form object.
+     * @return void
+     */
     public function extend_add_instance_form_definition($mform) {
         $fileformatoptions = [
             'csv' => 'CSV',
@@ -127,7 +168,7 @@ class step extends libbase {
 
         // Check if XMLWriter is available.
         // Available data formats are installed under 'dataformat' folder.
-        // We need to install https://moodle.org/plugins/dataformat_xml
+        // We need to install https://moodle.org/plugins/dataformat_xml.
         $classname = 'dataformat_xml\writer';
         if (class_exists($classname)) {
             $fileformatoptions['xml'] = 'XML';
@@ -139,17 +180,19 @@ class step extends libbase {
         );
         $mform->setType('fileformat', PARAM_TEXT);
         $mform->setDefault('fileformat', 'csv');
-
     }
 
-    public function get_plugin_settings()
-    {
+    /**
+     * Returns the instance settings.
+     *
+     * @return void
+     */
+    public function get_plugin_settings() {
         global $ADMIN;
         // Page to show the logs.
         $ADMIN->add('lifecycle_category', new admin_externalpage('tool_lcbackupcourselogstep_logs',
             get_string('courselogs', 'tool_lcbackupcourselogstep'),
             new moodle_url('/admin/tool/lcbackupcourselogstep/logs.php')));
-
     }
 
 }

--- a/classes/lifecycle/step.php
+++ b/classes/lifecycle/step.php
@@ -82,7 +82,7 @@ class step extends libbase {
 
         // Prepare file record.
         $filerecord = [
-            'contextid' => \context_course::instance($course->id)->id,
+            'contextid' => \context_system::instance()->id,
             'component' => 'tool_lcbackupcourselogstep',
             'filearea' => 'course_log',
             'itemid' => $instanceid,
@@ -99,7 +99,15 @@ class step extends libbase {
         }
 
         // Write data to file.
-        dataformat::write_data_to_filearea($filerecord, $fileformat, $columns, $logs);
+        $newfile = dataformat::write_data_to_filearea($filerecord, $fileformat, $columns, $logs);
+
+        $DB->insert_record('tool_lcbackupcourselogstep_metadata', [
+            'shortname' => $course->shortname,
+            'fullname' => $course->fullname,
+            'oldcourseid' => $course->id,
+            'fileid' => $newfile->get_id(),
+            'timecreated' => time()
+        ]);
 
         // Proceed.
         return step_response::proceed();

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -19,9 +19,10 @@ namespace tool_lcbackupcourselogstep\privacy;
 use core_privacy\local\metadata\null_provider;
 
 /**
- * Privacy subsystem implementation for tool_samplestep.
+ * Privacy subsystem implementation for tool_lcbackupcourselogstep.
  *
- * @package     tool_samplestep
+ * @package     tool_lcbackupcourselogstep
+ * @copyright   2024 Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class provider implements null_provider {
@@ -32,7 +33,7 @@ class provider implements null_provider {
      *
      * @return string the reason
      */
-    public static function get_reason() : string {
+    public static function get_reason(): string {
         return 'privacy:metadata';
     }
 }

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<XMLDB PATH="admin/tool/lcbackupcourselogstep/db" VERSION="2024102000" COMMENT="XMLDB file for Moodle tool/lcbackupcourselogstep"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
+>
+  <TABLES>
+    <TABLE NAME="tool_lcbackupcourselogstep_metadata" COMMENT="Metadata for course logs.">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="shortname" TYPE="char" LENGTH="255" NOTNULL="true"/>
+        <FIELD NAME="fullname" TYPE="char" LENGTH="255" NOTNULL="true"/>
+        <FIELD NAME="oldcourseid" TYPE="int" LENGTH="10" NOTNULL="true"/>
+        <FIELD NAME="fileid" TYPE="int" LENGTH="10" NOTNULL="true"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" COMMENT="Timestamp when the log file was created"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="fileid_fk" TYPE="foreign" FIELDS="fileid" REFTABLE="files" REFFIELDS="id"/>
+      </KEYS>
+    </TABLE>
+  </TABLES>
+</XMLDB>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -18,10 +18,16 @@
  * This file handles database upgrades for tool_lcbackupcourselogstep.
  *
  * @package   tool_lcbackupcourselogstep
- * @copyright 2024 Catalyst
+ * @copyright 2024 Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+/**
+ * Handles database upgrades for tool_lcbackupcourselogstep.
+ *
+ * @param int $oldversion The version of the plugin being upgraded from.
+ * @return bool True on success, false on failure.
+ */
 function xmldb_tool_lcbackupcourselogstep_upgrade($oldversion) {
     global $DB;
 
@@ -61,7 +67,7 @@ function xmldb_tool_lcbackupcourselogstep_upgrade($oldversion) {
         $DB->execute($sql1, [
             'contextlevel' => CONTEXT_COURSE,
             'component' => 'tool_lcbackupcourselogstep',
-            'filearea' => 'course_log'
+            'filearea' => 'course_log',
         ]);
 
         $sql2 = "
@@ -80,7 +86,7 @@ function xmldb_tool_lcbackupcourselogstep_upgrade($oldversion) {
             'contextid' => \context_system::instance()->id,
             'contextlevel' => CONTEXT_COURSE,
             'component' => 'tool_lcbackupcourselogstep',
-            'filearea' => 'course_log'
+            'filearea' => 'course_log',
         ]);
 
         upgrade_plugin_savepoint(true, 2024102000, 'tool', 'lcbackupcourselogstep');

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,0 +1,90 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * This file handles database upgrades for tool_lcbackupcourselogstep.
+ *
+ * @package   tool_lcbackupcourselogstep
+ * @copyright 2024 Catalyst
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+function xmldb_tool_lcbackupcourselogstep_upgrade($oldversion) {
+    global $DB;
+
+    if ($oldversion < 2024102000) {
+
+        $table = new xmldb_table('tool_lcbackupcourselogstep_metadata');
+
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('shortname', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('fullname', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('oldcourseid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('fileid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('fileid_fk', XMLDB_KEY_FOREIGN, ['fileid'], 'files', ['id']);
+
+        if (!$DB->get_manager()->table_exists($table)) {
+            $DB->get_manager()->create_table($table);
+        }
+
+        $sql1 = "
+            INSERT INTO {tool_lcbackupcourselogstep_metadata} (shortname, fullname, oldcourseid, fileid, timecreated)
+            SELECT crs.shortname,
+                   crs.fullname,
+                   crs.id AS oldcourseid,
+                   f.id AS fileid,
+                   f.timecreated
+              FROM {files} f
+              JOIN {context} ctx ON ctx.id = f.contextid
+              JOIN {course} crs ON ctx.instanceid = crs.id
+             WHERE ctx.contextlevel = :contextlevel
+               AND f.component = :component
+               AND f.filearea = :filearea
+               AND f.filesize > 0
+        ";
+        $DB->execute($sql1, [
+            'contextlevel' => CONTEXT_COURSE,
+            'component' => 'tool_lcbackupcourselogstep',
+            'filearea' => 'course_log'
+        ]);
+
+        $sql2 = "
+            UPDATE {files}
+               SET contextid = :contextid
+             WHERE id IN (
+                    SELECT f.id
+                      FROM {files} f
+                      JOIN {context} ctx ON ctx.id = f.contextid
+                     WHERE ctx.contextlevel = :contextlevel
+                       AND f.component = :component
+                       AND f.filearea = :filearea
+                   )
+        ";
+        $DB->execute($sql2, [
+            'contextid' => \context_system::instance()->id,
+            'contextlevel' => CONTEXT_COURSE,
+            'component' => 'tool_lcbackupcourselogstep',
+            'filearea' => 'course_log'
+        ]);
+
+        upgrade_plugin_savepoint(true, 2024102000, 'tool', 'lcbackupcourselogstep');
+    }
+
+    return true;
+}

--- a/lang/en/tool_lcbackupcourselogstep.php
+++ b/lang/en/tool_lcbackupcourselogstep.php
@@ -22,5 +22,6 @@ $string['course_id_header'] = 'Course ID';
 $string['course_shortname_header'] = 'Course short name';
 $string['course_fullname_header'] = 'Course fullname name';
 $string['filename_header'] = 'File name';
+$string['filesize_header'] = 'File size';
 $string['createdat_header'] = 'Created at';
 $string['actions_header'] = 'Actions';

--- a/lang/en/tool_lcbackupcourselogstep.php
+++ b/lang/en/tool_lcbackupcourselogstep.php
@@ -14,6 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * String definitions for the tool_lcbackupcourselogstep plugin.
+ *
+ * @package     tool_lcbackupcourselogstep
+ * @copyright   2024 Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 $string['pluginname'] = 'Backup course log step';
 $string['privacy:metadata'] = 'The plugin does not store any personal data.';
 $string['fileformat'] = 'Log file format.';

--- a/logs.php
+++ b/logs.php
@@ -15,9 +15,10 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Displays backed up logs
+ * Displays backed up logs.
  *
- * @package tool_lcbackupcourselogstep
+ * @package    tool_lcbackupcourselogstep
+ * @copyright  2024 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/tests/step_test.php
+++ b/tests/step_test.php
@@ -101,7 +101,7 @@ class step_test extends \advanced_testcase {
         $processor->process_courses();
 
         // Check that the log file is created.
-        $contextid = \context_course::instance($this->course->id)->id;
+        $contextid = \context_system::instance()->id;
         $sql = "contextid = :contextid
                AND component = :component
                AND filearea = :filearea

--- a/tests/step_test.php
+++ b/tests/step_test.php
@@ -18,6 +18,7 @@
  * Trigger test for end date delay trigger.
  *
  * @package    tool_lcbackupcourselogstep
+ * @copyright  2024 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 namespace tool_lcbackupcourselogstep\tests;
@@ -31,8 +32,6 @@ use tool_lifecycle\local\manager\workflow_manager;
 use tool_lifecycle\processor;
 use tool_lifecycle\settings_type;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Trigger test for start date delay trigger.
  *
@@ -40,22 +39,43 @@ defined('MOODLE_INTERNAL') || die();
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class step_test extends \advanced_testcase {
-    /** Icon of the manual trigger. */
+
+    /**
+     * Icon of the manual trigger.
+     * @var string
+     */
     const MANUAL_TRIGGER1_ICON = 't/up';
 
-    /** Display name of the manual trigger. */
+    /**
+     * Display name of the manual trigger.
+     * @var string
+     */
     const MANUAL_TRIGGER1_DISPLAYNAME = 'Up';
 
-    /** Capability of the manual trigger. */
+    /**
+     * Capability of the manual trigger.
+     * @var string
+     */
     const MANUAL_TRIGGER1_CAPABILITY = 'moodle/course:manageactivities';
 
-    /** @var trigger_subplugin $trigger Instances of the triggers under test. */
+    /**
+     * Instances of the triggers under test.
+     * @var trigger_subplugin
+     */
     private $trigger;
 
-    /** @var \stdClass $course Instance of the course under test. */
+    /**
+     * Instance of the course under test.
+     * @var \stdClass
+     */
     private $course;
 
-    public function setUp() : void {
+    /**
+     * Set up the test case.
+     *
+     * @return void
+     */
+    public function setUp(): void {
         global $USER, $DB;
 
         // We do not need a sesskey check in these tests.
@@ -75,7 +95,7 @@ class step_test extends \advanced_testcase {
         // Step.
         $step = $generator->create_step("instance1", "tool_lcbackupcourselogstep", $manualworkflow->id);
         settings_manager::save_settings($step->id, settings_type::STEP, "tool_lcbackupcourselogstep",
-            array("fileformat" => "csv")
+            ["fileformat" => "csv"]
         );
 
         // Course.
@@ -86,7 +106,9 @@ class step_test extends \advanced_testcase {
     }
 
     /**
-     * Test course is hidden.
+     * Test that the notification step creates a log file.
+     * @covers \tool_lcbackupcourselogstep\step::process_course
+     * @return void
      */
     public function test_notification_step() {
         global $DB;
@@ -112,7 +134,7 @@ class step_test extends \advanced_testcase {
                 'component' => 'tool_lcbackupcourselogstep',
                 'filearea' => 'course_log',
                 'filepath' => '/',
-                'filename' => '.'
+                'filename' => '.',
             ]
         );
 
@@ -122,8 +144,11 @@ class step_test extends \advanced_testcase {
         // Check file name pattern.
         $this->assertThat($file->filename, $this->logicalAnd(
             $this->isType('string'),
-            $this->matchesRegularExpression('/^course_log_' . $this->course->shortname . '_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.csv$/')
+            $this->matchesRegularExpression(
+                '/^course_log_' . $this->course->shortname . '_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.csv$/'
+            )
         ));
     }
 
 }
+

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023100400;
+$plugin->version   = 2024102000;
 $plugin->requires  = 2022041200;
 $plugin->component = 'tool_lcbackupcourselogstep';
 

--- a/version.php
+++ b/version.php
@@ -15,10 +15,11 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Backup course log
+ * Version details.
  *
- * @package    tool_lcbackupcourselogstep
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package     tool_lcbackupcourselogstep
+ * @copyright   2024 Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
@@ -27,6 +28,6 @@ $plugin->version   = 2024102000;
 $plugin->requires  = 2022041200;
 $plugin->component = 'tool_lcbackupcourselogstep';
 
-$plugin->dependencies = array(
-    'tool_lifecycle' => 2023050201
-);
+$plugin->dependencies = [
+    'tool_lifecycle' => 2023050201,
+];


### PR DESCRIPTION
This PR addresses the issue in #1

**To Test**

Create a test site with a course (use admin/tool/generator/cli/maketestsite.php).

Create a category where you can move the course into.

Move the course into the the newly created category.

Open `admin/tool/lifecycle/workflowdrafts.php` and click "Create new workflow" button.

Give the workflow a new title, then click "Save changes".

From the "Add new trigger instance" dropdown, select "Categories Trigger"

Give the new trigger a name, and Select the Category from the dropdown then click Save changes.

From the "Add new step instance" dropdown, select "Backup course log step"

Give the new step a name, then click "Save changes".

Open `admin/tool/lifecycle/workflowdrafts.php` and click the Activate button for the newly created workflow.

In a terminal execute the following command

`php admin/cli/scheduled_task.php --execute="\tool_lifecycle\task\lifecycle_task"`

After executing the task, make sure the log file is generated for that course by checking this link:

`admin/tool/lcbackupcourselogstep/logs.php`

After this, delete the course by going to `/course/management.php` and deleting the course that you used to create a log file.

Then, open this page: `admin/tool/lcbackupcourselogstep/logs.php` 
Confirm you can still see the log file with the course name and ID (confirm in the database that the course is deleted and that the `mdl_tool_lcbackupcourselogstep_metadata` table contains this data).
